### PR TITLE
change recent courses from fa-book to fa-history

### DIFF
--- a/templates/core/full_header.mustache
+++ b/templates/core/full_header.mustache
@@ -33,7 +33,7 @@
     <div class="w-100">
         {{#hasmycourses}}
             <div class="dropdownmycourses">
-              <a href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-tooltip="tooltip" data-placement= "right" title="{{{mycourses}}}" class="btn btn-secondary mycourseicon mycourses" style="float:right;"><i class="fa-2x fa fa-book mycourses"></i></a>
+              <a href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-tooltip="tooltip" data-placement= "right" title="{{{mycourses}}}" class="btn btn-secondary mycourseicon mycourses" style="float:right;"><i class="fa-2x fa fa-history mycourses"></i></a>
 
                 <div class="dropdown-menu dropdown-menu-right iconsidebar">
                   <h5>{{{mycourses}}}</h5>


### PR DESCRIPTION
The fa-book icon on the recent courses menu seems incongruent with the function provided.  fa-history would be a better indication of what the menu is for.  This is merely a change to the moustache template to that end.