### PR TITLE
enable removedprimarynavitems in settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+pix/.DS_Store

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -29,9 +29,12 @@ use custom_menu;
 use stdClass;
 use moodle_url;
 use context_course;
+use local_nattylocal\progresscount;
 
 
 require_once ($CFG->dirroot . '/completion/classes/progress.php');
+// ADDED tinjohn 180123.
+require_once ($CFG->dirroot . '/local/nattylocal/classes/progresscount.php');
 
 
 class core_renderer extends \theme_boost\output\core_renderer {
@@ -46,12 +49,15 @@ class core_renderer extends \theme_boost\output\core_renderer {
         if (\core_completion\progress::get_course_progress_percentage($PAGE->course)) {
             $comppc = \core_completion\progress::get_course_progress_percentage($PAGE->course);
             $comppercent = number_format($comppc, 0);
+            // ADDED tinjohn 180123.
+            $comppcnt = progresscount::get_course_progress_count($PAGE->course);
+            
         }
         else {
             $comppercent = 0;
         }
 
-        $progresschartcontext = ['progress' => $comppercent, 'hasprogressbar' => $hasprogressbar];
+        $progresschartcontext = ['progress' => $comppercent, 'progresscnt' => $comppcnt, 'hasprogressbar' => $hasprogressbar];
         $progress = $this->render_from_template('theme_learnr/progress-bar', $progresschartcontext);
 
         return $progress;

--- a/config.php
+++ b/config.php
@@ -224,3 +224,5 @@ if ($THEME->settings->showcourseindexnav == 1) {
 }
 // ADDED tinjohn 20221206.
 $THEME->removedprimarynavitems = explode(',', $THEME->settings->removedprimarynavitems);
+// ADDED tinjohn 20231701.
+$THEME->javascripts_footer = array('dynprogressbar');

--- a/config.php
+++ b/config.php
@@ -173,7 +173,7 @@ if ($THEME->settings->showheaderblockpanel == 1 && $THEME->settings->showblockdr
         'defaultregion' => 'side-pre',
         'options' => ['langmenu' => true],
     ];
-} 
+}
 if ($THEME->settings->showheaderblockpanel == 0 && $THEME->settings->showblockdrawer == 1){
     $THEME->layouts['course'] = [
         'file' => 'course.php',
@@ -222,3 +222,5 @@ if ($THEME->settings->showcourseindexnav == 1) {
 } else {
     $THEME->usescourseindex = false;
 }
+// ADDED tinjohn 20221206.
+$THEME->removedprimarynavitems = explode(',', $THEME->settings->removedprimarynavitems);

--- a/javascript/dynprogressbar.js
+++ b/javascript/dynprogressbar.js
@@ -1,0 +1,58 @@
+window.addEventListener('load', function () {
+    // get the progressbar
+    var pr = document.getElementsByClassName('progress')[0];
+    var prbar = document.getElementsByClassName('progress-bar progress-bar-info')[0];
+    console.log('pr' + pr);
+    console.log('prbar' + prbar);
+})
+
+// https://riptutorial.com/javascript/example/20197/listening-to-ajax-events-at-a-global-level
+// Store a reference to the native method
+let send = XMLHttpRequest.prototype.send;
+
+// Overwrite the native method
+XMLHttpRequest.prototype.send = function() {
+    // tinjohn get Request Payload from send arguments
+    payload = arguments[0];
+    console.log("arguments 0 send-----" + payload);
+    var isValidJSON = true;
+    try { JSON.parse(payload) } catch { isValidJSON = false }
+    if(isValidJSON) {
+        // Assign an event listener
+        // and remove it again
+        // https://www.mediaevent.de/javascript/remove-event-listener.html
+        this.addEventListener("load", function removeMe () { 
+            readAJAXrequestsend(payload);
+            this.removeEventListener("load", removeMe);
+        }, false);
+    }
+    // Call the stored reference to the native method
+    send.apply(this, arguments);
+};
+
+function readAJAXrequestsend (payload) {
+    console.log("readAJAXrequestsend-----payload---------" + payload);
+    var isValidJSON = true;
+    try { JSON.parse(payload) } catch { isValidJSON = false }
+    if(isValidJSON) {
+        const plo = JSON.parse(payload);
+        /*    
+        console.log(plo[0].methodname);
+        console.log(plo[0].args.cmid);
+        console.log(plo[0].args.completed);
+        */
+        // update_activity_completion_status_manually in completion/external.php
+        if (plo[0].methodname.match("(.*)core_completion_update_activity_completion_status_manually(.*)")) 
+        {
+            var prbar = document.getElementsByClassName('progress-bar progress-bar-info')[0];
+            if (plo[0].args.completed) {
+                prbar.style.width = (parseInt(prbar.style.width) + parseInt(prbar.getAttribute('progress-steps'))) + '%';              
+            } else {
+                prbar.style.width = (parseInt(prbar.style.width) - parseInt(prbar.getAttribute('progress-steps'))) + '%';      
+            }
+        }
+        payload = '';
+    }
+}
+
+

--- a/lang/en/theme_learnr.php
+++ b/lang/en/theme_learnr.php
@@ -213,3 +213,5 @@ $string['displaybottom'] = 'Display at Bottom of Page';
 $string['markettextbg'] = 'Marketing Tile Text Background';
 $string['markettextbg_desc'] = 'Background colour for the text area of the marketing tiles.';
 
+$string['removedprimarynavitems'] = 'Unneeded navigation items';
+$string['removedprimarynavitems_desc'] = 'The items specified are not shown in the navigation menu.';

--- a/settings.php
+++ b/settings.php
@@ -29,6 +29,16 @@ if ($ADMIN->fulltree) {
     $settings = new theme_boost_admin_settingspage_tabs('themesettinglearnr', get_string('configtitle', 'theme_learnr'));
     $page = new admin_settingpage('theme_learnr_general', get_string('generalsettings', 'theme_boost'));
 
+
+    // ADDED tinjohn 20221206.
+    // Removedprimarynavitems.
+    // Nav items to be excluded when this theme is enabled.
+    $default = '';
+    $setting = new admin_setting_configtext('theme_learnr/removedprimarynavitems',
+                get_string('removedprimarynavitems', 'theme_learnr'), get_string('removedprimarynavitems_desc', 'theme_learnr'), $default, PARAM_TEXT);
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $page->add($setting);
+
     // Unaddable blocks.
     // Blocks to be excluded when this theme is enabled in the "Add a block" list: Administration, Navigation, Courses and
     // Section links.
@@ -42,6 +52,7 @@ if ($ADMIN->fulltree) {
     $title = get_string('preset', 'theme_boost');
     $description = get_string('preset_desc', 'theme_boost');
     $default = 'default.scss';
+
 
     $context = context_system::instance();
     $fs = get_file_storage();
@@ -471,7 +482,7 @@ if ($ADMIN->fulltree) {
     $description = get_string('alert_desc', 'theme_learnr');
     $default = '';
     $setting = new admin_setting_confightmleditor($name, $title, $description, $default);
-    
+
     $page->add($setting);
 
     // Frontpage Textbox.
@@ -480,7 +491,7 @@ if ($ADMIN->fulltree) {
     $description = get_string('fptextbox_desc', 'theme_learnr');
     $default = '';
     $setting = new admin_setting_confightmleditor($name, $title, $description, $default);
-    
+
     $page->add($setting);
 
     $settings->add($page);


### PR DESCRIPTION
Moodle 4.0 upgrade.txt: A new theme config 'removedprimarynavitems' allows a theme to customise primary navigation by specifying the list of items to remove. While function exists, strings are still missing thus added here to theme.